### PR TITLE
Scala 2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: scala
 scala:
-  - 2.12.1
-  - 2.11.8
+  - 2.12.8
+  - 2.11.11
+  - 2.13.0
 jdk:
   - oraclejdk8
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,29 +1,29 @@
 name := "sangria-argonaut"
 organization := "org.sangria-graphql"
-version := "1.0.1-SNAPSHOT"
+version := "1.0.2-SNAPSHOT"
 
 description := "Sangria argonaut marshalling"
 homepage := Some(url("http://sangria-graphql.org"))
 licenses := Seq("Apache License, ASL Version 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
 
-scalaVersion := "2.12.1"
-crossScalaVersions := Seq("2.11.8", "2.12.1")
+scalaVersion := "2.13.0"
+crossScalaVersions := Seq("2.11.11", "2.12.8", scalaVersion.value)
 
 scalacOptions ++= Seq("-deprecation", "-feature")
 
 scalacOptions ++= {
-  if (scalaVersion.value startsWith "2.12")
-    Seq.empty
-  else
+  if (scalaVersion.value startsWith "2.11")
     Seq("-target:jvm-1.7")
+  else
+    Seq.empty
 }
 
 libraryDependencies ++= Seq(
-  "org.sangria-graphql" %% "sangria-marshalling-api" % "1.0.0",
-  "io.argonaut" %% "argonaut" % "6.2-RC2",
+  "org.sangria-graphql" %% "sangria-marshalling-api" % "2.0.0-SNAPSHOT",
+  "io.argonaut" %% "argonaut" % "6.2.3",
 
-  "org.sangria-graphql" %% "sangria-marshalling-testkit" % "1.0.0" % "test",
-  "org.scalatest" %% "scalatest" % "3.0.1" % "test"
+  "org.sangria-graphql" %% "sangria-marshalling-testkit" % "1.1.0-SNAPSHOT" % Test,
+  "org.scalatest" %% "scalatest" % "3.0.8" % "test"
 )
 
 git.remoteRepo := "git@github.com:sangria-graphql/sangria-argonaut.git"
@@ -41,9 +41,8 @@ publishTo := Some(
 
 // Site and docs
 
-site.settings
-site.includeScaladoc()
-ghpages.settings
+enablePlugins(SiteScaladocPlugin)
+enablePlugins(GhpagesPlugin)
 
 // nice *magenta* prompt!
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.6.4")
-addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.8.1")
-addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.3")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.3")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.7")

--- a/src/main/scala/sangria/marshalling/argonaut.scala
+++ b/src/main/scala/sangria/marshalling/argonaut.scala
@@ -18,20 +18,20 @@ object argonaut {
 
     def arrayNode(values: Vector[Json]) = Json.array(values: _*)
     def optionalArrayNodeValue(value: Option[Json]) = value match {
-      case Some(v) ⇒ v
-      case None ⇒ nullNode
+      case Some(v) => v
+      case None => nullNode
     }
 
     def scalarNode(value: Any, typeName: String, info: Set[ScalarValueInfo]) = value match {
-      case v: String ⇒ Json.jString(v)
-      case v: Boolean ⇒ Json.jBool(v)
-      case v: Int ⇒ Json.jNumber(v)
-      case v: Long ⇒ Json.jNumber(v)
-      case v: Float ⇒ Json.jNumber(v).get
-      case v: Double ⇒ Json.jNumber(v).get
-      case v: BigInt ⇒ Json.jNumber(BigDecimal(v))
-      case v: BigDecimal ⇒ Json.jNumber(v)
-      case v ⇒ throw new IllegalArgumentException("Unsupported scalar value: " + v)
+      case v: String => Json.jString(v)
+      case v: Boolean => Json.jBool(v)
+      case v: Int => Json.jNumber(v)
+      case v: Long => Json.jNumber(v)
+      case v: Float => Json.jNumber(v).get
+      case v: Double => Json.jNumber(v).get
+      case v: BigInt => Json.jNumber(BigDecimal(v))
+      case v: BigDecimal => Json.jNumber(v)
+      case v => throw new IllegalArgumentException("Unsupported scalar value: " + v)
     }
 
     def enumNode(value: String, typeName: String) = Json.jString(value)
@@ -93,18 +93,18 @@ object argonaut {
 
   implicit def argonautEncodeJsonToInput[T : EncodeJson]: ToInput[T, Json] =
     new ToInput[T, Json] {
-      def toInput(value: T) = implicitly[EncodeJson[T]].apply(value) → ArgonautInputUnmarshaller
+      def toInput(value: T) = implicitly[EncodeJson[T]].apply(value) -> ArgonautInputUnmarshaller
     }
 
   implicit def argonautDecoderFromInput[T : DecodeJson]: FromInput[T] =
     new FromInput[T] {
       val marshaller = ArgonautResultMarshaller
       def fromResult(node: marshaller.Node) =
-        implicitly[DecodeJson[T]].decodeJson(node).fold((error, _) ⇒ throw InputParsingError(Vector(error)), identity)
+        implicitly[DecodeJson[T]].decodeJson(node).fold((error, _) => throw InputParsingError(Vector(error)), identity)
     }
 
   implicit object ArgonautInputParser extends InputParser[Json] {
-    def parse(str: String) = str.decodeEither[Json].fold(error ⇒ Failure(ArgonautParsingException(error)), Success(_))
+    def parse(str: String) = str.decodeEither[Json].fold(error => Failure(ArgonautParsingException(error)), Success(_))
   }
 
   case class ArgonautParsingException(message: String) extends Exception(message)

--- a/src/test/scala/sangria/marshalling/ArgonautSupportSpec.scala
+++ b/src/test/scala/sangria/marshalling/ArgonautSupportSpec.scala
@@ -34,10 +34,10 @@ class ArgonautSupportSpec extends WordSpec with Matchers with MarshallingBehavio
   }
 
   val toRender = Json.obj(
-    "a" → Json.array(Json.jNull, Json.jNumber(123), Json.array(Json.obj("foo" → Json.jString("bar")))),
-    "b" → Json.obj(
-      "c" → Json.jBool(true),
-      "d" → Json.jNull))
+    "a" -> Json.array(Json.jNull, Json.jNumber(123), Json.array(Json.obj("foo" -> Json.jString("bar")))),
+    "b" -> Json.obj(
+      "c" -> Json.jBool(true),
+      "d" -> Json.jNull))
 
   "InputUnmarshaller" should {
     "throw an exception on invalid scalar values" in {


### PR DESCRIPTION
In order for sangria to target 2.13, the dependencies must target 2.13.

- 2.12 build was bumped to the latest version
- 2.11 build was bumped to the latest version
- bumped minor version number
- added cross-build with scala 2.13
- replaced deprecated unicode arrows with plain ones

This was built against marshalling-api 2.0.0-snapshot and marshalling-testkit 1.1.0-snapshot published locally from:
https://github.com/sangria-graphql/sangria-marshalling-api/pull/4
https://github.com/sangria-graphql/sangria-marshalling-testkit/pull/2